### PR TITLE
Fixed an issue where car heading would affect handling parameters.

### DIFF
--- a/Assets/Scripts/Car.cs
+++ b/Assets/Scripts/Car.cs
@@ -137,8 +137,8 @@ public class Car : MonoBehaviour {
 		AbsoluteVelocity = 0;
 
 		// Dimensions
-		AxleFront.DistanceToCG = Mathf.Abs(CenterOfGravity.transform.position.y - AxleFront.transform.Find("Axle").transform.position.y);
-		AxleRear.DistanceToCG = Mathf.Abs(CenterOfGravity.transform.position.y - AxleRear.transform.Find("Axle").transform.position.y);
+		AxleFront.DistanceToCG = Vector2.Distance(CenterOfGravity.transform.position, AxleFront.transform.Find("Axle").transform.position);
+		AxleRear.DistanceToCG = Vector2.Distance(CenterOfGravity.transform.position, AxleRear.transform.Find("Axle").transform.position);
 		// Extend the calculations past actual car dimensions for better simulation
 		AxleFront.DistanceToCG *= AxleDistanceCorrection;
 		AxleRear.DistanceToCG *= AxleDistanceCorrection;
@@ -156,7 +156,7 @@ public class Car : MonoBehaviour {
 		AxleFront.Init (Rigidbody2D, WheelBase);
 		AxleRear.Init (Rigidbody2D, WheelBase);
 
-		TrackWidth = Mathf.Abs (AxleRear.TireLeft.transform.position.x - AxleRear.TireRight.transform.position.x);
+		TrackWidth = Vector2.Distance(AxleRear.TireLeft.transform.position, AxleRear.TireRight.transform.position);
 	}
 
 	void Update() {


### PR DESCRIPTION
This resolves jongallant/CarSimulator#3 .

An alternate solution is to use transform.localPosition rather than transform.position, but this negatively affected handling for me because it effectively ignores object scaling.  Maybe you want this.

A disadvantage of using Vector2.Distance is that it's more subject to rounding errors.